### PR TITLE
chore(peer-deps): allow Expo SDK peerDependency higher than version 49

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prebuild"
   ],
   "peerDependencies": {
-    "expo": "^49"
+    "expo": ">=49"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
Allow support and fix NPM errors when using this plugin with an Expo SDK version higher than 49. 
Fixes issue #4